### PR TITLE
- added a charset field to append to contenttype

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -55,6 +55,12 @@ You can configure the policy with the following options :
 |'SOAPAction' HTTP header send when invoking WS
 |
 
+|Charset
+|
+|
+|This charset will be appended to the Content-Type header value
+|
+
 |===
 
 

--- a/src/main/java/io/gravitee/policy/rest2soap/RestToSoapTransformerPolicy.java
+++ b/src/main/java/io/gravitee/policy/rest2soap/RestToSoapTransformerPolicy.java
@@ -70,9 +70,11 @@ public class RestToSoapTransformerPolicy {
 
     @OnRequestContent
     public ReadWriteStream onRequestContent(Request request, ExecutionContext executionContext) {
+        String charset =  soapTransformerPolicyConfiguration.getCharset() ;
+	String content_type = (charset == null || charset.trim().equals("") ? MediaType.TEXT_XML : MediaType.TEXT_XML + "; charset="+charset ) ;
         return TransformableRequestStreamBuilder
                 .on(request)
-                .contentType(MediaType.TEXT_XML)
+		.contentType(content_type)
                 .transform(
                         buffer -> {
                             executionContext.getTemplateEngine().getTemplateContext().setVariable("request",

--- a/src/main/java/io/gravitee/policy/rest2soap/configuration/SoapTransformerPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/rest2soap/configuration/SoapTransformerPolicyConfiguration.java
@@ -27,6 +27,8 @@ public class SoapTransformerPolicyConfiguration implements PolicyConfiguration {
 
     private String soapAction;
 
+    private String charset;
+
     public String getEnvelope() {
         return envelope;
     }
@@ -42,4 +44,13 @@ public class SoapTransformerPolicyConfiguration implements PolicyConfiguration {
     public void setSoapAction(String soapAction) {
         this.soapAction = soapAction;
     }
+
+    public String getCharset() {
+        return charset;
+    }
+
+    public void setCharset(String charset) {
+        this.charset = charset;
+    }
+
 }

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -22,6 +22,11 @@
       "title": "SOAP Action",
       "description": "'SOAPAction' HTTP header send when invoking WS",
       "type": "string"
+    },
+    "charset": {
+      "title": "Charset",
+      "description": "This charset will be appended to the Content-Type header value",
+      "type": "string"
     }
   },
   "required": [


### PR DESCRIPTION
- by default - contenttype is text/xml
- when charset = UTF-8, contenttype of the outgoing request will be text/xml; UTF-8

