### PR TITLE
feat(management): Create api from wsdl

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -61,6 +61,12 @@ You can configure the policy with the following options :
 |This charset will be appended to the Content-Type header value
 |
 
+|Preserve Query Parameters
+|
+|
+|This option specify if the query parameters are propagated to the backend SOAP service
+|
+
 |===
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,9 +34,11 @@
     </parent>
 
     <properties>
-        <gravitee-gateway-api.version>1.18.0</gravitee-gateway-api.version>
-        <gravitee-policy-api.version>1.6.0</gravitee-policy-api.version>
-        <gravitee-common.version>1.15.0</gravitee-common.version>
+        <gravitee-gateway-api.version>1.20.0</gravitee-gateway-api.version>
+        <gravitee-policy-api.version>1.8.0</gravitee-policy-api.version>
+        <gravitee-common.version>1.17.0</gravitee-common.version>
+
+        <swagger-parser.version>2.0.14</swagger-parser.version>
 
         <json-schema-generator-maven-plugin.version>1.1.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>
@@ -71,6 +73,14 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Swagger -->
+        <dependency>
+            <groupId>io.swagger.parser.v3</groupId>
+            <artifactId>swagger-parser</artifactId>
+            <version>${swagger-parser.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/io/gravitee/policy/rest2soap/RestToSoapTransformerPolicy.java
+++ b/src/main/java/io/gravitee/policy/rest2soap/RestToSoapTransformerPolicy.java
@@ -18,11 +18,15 @@ package io.gravitee.policy.rest2soap;
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.common.http.MediaType;
+import io.gravitee.common.util.LinkedMultiValueMap;
+import io.gravitee.common.util.MultiValueMap;
 import io.gravitee.el.exceptions.ELNullEvaluationException;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.api.RequestWrapper;
 import io.gravitee.gateway.api.Response;
 import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.api.context.MutableExecutionContext;
 import io.gravitee.gateway.api.http.stream.TransformableRequestStreamBuilder;
 import io.gravitee.gateway.api.stream.ReadWriteStream;
 import io.gravitee.policy.api.PolicyChain;
@@ -67,18 +71,27 @@ public class RestToSoapTransformerPolicy {
             request.headers().set(SOAP_ACTION_HEADER, soapTransformerPolicyConfiguration.getSoapAction());
         }
 
+        // The ManagedRequestWrapper removes pathInfo for SOAP request in order to use the Server URL as defined into the OpenAPI spec
+        // it also hides the query parameters if required, the query parameter may be used as variable in the template, so to allow
+        // the template engine to process query parameters we have to hide them from the EndpointInvoker but preserve them in the original request.
+        if (executionContext instanceof MutableExecutionContext) {
+            ((MutableExecutionContext) executionContext)
+                    .request(new RestToSoapResquestWrapper(executionContext.request(), !soapTransformerPolicyConfiguration.isPreserveQueryParams()));
+        }
+
         policyChain.doNext(request, response);
     }
 
     @OnRequestContent
     public ReadWriteStream onRequestContent(Request request, ExecutionContext executionContext, PolicyChain policyChain) {
         String charset =  soapTransformerPolicyConfiguration.getCharset() ;
-	String contentType = (charset == null || charset.isEmpty() ? MediaType.TEXT_XML : MediaType.TEXT_XML + "; charset="+charset);
+        String contentType = (charset == null || charset.isEmpty() ? MediaType.TEXT_XML : MediaType.TEXT_XML + "; charset="+charset);
         return TransformableRequestStreamBuilder
                 .on(request)
 		.contentType(contentType)
                 .transform(
                         buffer -> {
+
                             executionContext.getTemplateEngine().getTemplateContext().setVariable("request",
                                     new ContentAwareEvaluableRequest(request, buffer.toString()));
 
@@ -95,5 +108,58 @@ public class RestToSoapTransformerPolicy {
                             return Buffer.buffer(soapEnvelope);
                         }
                 ).build();
+    }
+
+    /**
+     * Use to hide the pathInfo and query parameters according to the wrapper options.
+     */
+    private static class RestToSoapResquestWrapper extends RequestWrapper {
+        /**
+         * hide the pathInfo attribute
+         */
+        private boolean hidePathInfo = true;
+        /**
+         * hide the query parameters
+         */
+        private boolean hideQueryParams = false;
+
+        public RestToSoapResquestWrapper(Request request, boolean  hideQueryParams) {
+            super(request);
+            this.hideQueryParams = hideQueryParams;
+        }
+
+        public boolean clearPathInfo() {
+            return hidePathInfo;
+        }
+
+        public void setHidePathInfo(boolean hidePathInfo) {
+            this.hidePathInfo = hidePathInfo;
+        }
+
+        public boolean clearQueryParams() {
+            return hideQueryParams;
+        }
+
+        public void setHideQueryParams(boolean hideQueryParams) {
+            this.hideQueryParams = hideQueryParams;
+        }
+
+        @Override
+        public String pathInfo() {
+            if (hidePathInfo) {
+                return "";
+            } else {
+                return super.pathInfo();
+            }
+        }
+
+        @Override
+        public MultiValueMap<String, String> parameters() {
+            if (hideQueryParams) {
+                return new LinkedMultiValueMap<>();
+            } else {
+                return super.parameters();
+            }
+        }
     }
 }

--- a/src/main/java/io/gravitee/policy/rest2soap/configuration/SoapTransformerPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/rest2soap/configuration/SoapTransformerPolicyConfiguration.java
@@ -29,6 +29,8 @@ public class SoapTransformerPolicyConfiguration implements PolicyConfiguration {
 
     private String charset;
 
+    private boolean preserveQueryParams = false;
+
     public String getEnvelope() {
         return envelope;
     }
@@ -53,4 +55,11 @@ public class SoapTransformerPolicyConfiguration implements PolicyConfiguration {
         this.charset = charset;
     }
 
+    public boolean isPreserveQueryParams() {
+        return preserveQueryParams;
+    }
+
+    public void setPreserveQueryParams(boolean preserveQueryParams) {
+        this.preserveQueryParams = preserveQueryParams;
+    }
 }

--- a/src/main/java/io/gravitee/policy/rest2soap/el/ContentAwareEvaluableRequest.java
+++ b/src/main/java/io/gravitee/policy/rest2soap/el/ContentAwareEvaluableRequest.java
@@ -30,7 +30,7 @@ public class ContentAwareEvaluableRequest {
 
     public ContentAwareEvaluableRequest(Request request, String content) {
         this.request = request;
-        this.content =content;
+        this.content = content;
     }
 
     public String getId() {

--- a/src/main/java/io/gravitee/policy/rest2soap/swagger/RestToSoapOAIOperationVisitor.java
+++ b/src/main/java/io/gravitee/policy/rest2soap/swagger/RestToSoapOAIOperationVisitor.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.rest2soap.swagger;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import io.gravitee.policy.api.swagger.Policy;
+import io.gravitee.policy.api.swagger.v3.OAIOperationVisitor;
+import io.gravitee.policy.rest2soap.configuration.SoapTransformerPolicyConfiguration;
+
+import java.util.Map;
+import java.util.Optional;
+/**
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class RestToSoapOAIOperationVisitor implements OAIOperationVisitor {
+
+    public static final String SOAP_EXTENSION_ENVELOPE = "x-graviteeio-soap-envelope";
+    public static final String SOAP_EXTENSION_ACTION = "x-graviteeio-soap-action";
+
+    private final ObjectMapper mapper  = new ObjectMapper();
+    {
+        mapper.configure(JsonGenerator.Feature.WRITE_NUMBERS_AS_STRINGS, true);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+    }
+
+    @Override
+    public Optional<Policy> visit(io.swagger.v3.oas.models.OpenAPI openAPI, io.swagger.v3.oas.models.Operation operation) {
+        Map<String, Object> extensions = operation.getExtensions();
+
+        if (extensions != null
+                && extensions.containsKey(SOAP_EXTENSION_ENVELOPE)) {
+            SoapTransformerPolicyConfiguration configuration = new SoapTransformerPolicyConfiguration();
+            try {
+                Policy policy = new Policy();
+                policy.setName("rest-to-soap");
+                configuration.setEnvelope((String) extensions.get(SOAP_EXTENSION_ENVELOPE));
+                configuration.setSoapAction((String) extensions.get(SOAP_EXTENSION_ACTION));
+                configuration.setCharset("");
+                configuration.setPreserveQueryParams(false);
+                policy.setConfiguration(mapper.writeValueAsString(configuration));
+                return Optional.of(policy);
+            } catch (JsonProcessingException e) {
+                e.printStackTrace();
+            }
+        }
+
+        return Optional.empty();
+    }
+}

--- a/src/main/java/io/gravitee/policy/rest2soap/swagger/RestToSoapSwaggerOperationVisitor.java
+++ b/src/main/java/io/gravitee/policy/rest2soap/swagger/RestToSoapSwaggerOperationVisitor.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.rest2soap.swagger;
+
+import io.gravitee.policy.api.swagger.Policy;
+import io.gravitee.policy.api.swagger.v2.SwaggerOperationVisitor;
+import io.swagger.models.Operation;
+import io.swagger.models.Swagger;
+
+import java.util.Optional;
+
+/**
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class RestToSoapSwaggerOperationVisitor implements SwaggerOperationVisitor {
+    @Override
+    public Optional<Policy> visit(Swagger swagger, Operation operation) {
+        // Vendor extension not available in swagger specification
+        return Optional.empty();
+    }
+}

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -27,6 +27,11 @@
       "title": "Charset",
       "description": "This charset will be appended to the Content-Type header value",
       "type": "string"
+    },
+    "preserveQueryParams": {
+      "title": "Preserve Query Parameters",
+      "description": "Define if the query parameters are propagated to the backend SOAP service",
+      "type": "boolean"
     }
   },
   "required": [

--- a/src/test/java/io/gravitee/policy/rest2soap/swagger/RestToSoapOAIOperationVisitorTest.java
+++ b/src/test/java/io/gravitee/policy/rest2soap/swagger/RestToSoapOAIOperationVisitorTest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.rest2soap.swagger;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.policy.api.swagger.Policy;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+import static org.junit.Assert.*;
+
+/**
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class RestToSoapOAIOperationVisitorTest {
+
+    private RestToSoapOAIOperationVisitor visitor = new RestToSoapOAIOperationVisitor();
+
+    @Test
+    public void operationWithoutExtension() {
+        Operation operationMock = mock(Operation.class);
+        when(operationMock.getExtensions()).thenReturn(null);
+        Optional<Policy> policy = visitor.visit(mock(OpenAPI.class), operationMock);
+        assertFalse(policy.isPresent());
+    }
+
+    @Test
+    public void operationWithoutSoapEnvelope() {
+        Map<String, Object> extensions = new HashMap<>();
+        extensions.put(RestToSoapOAIOperationVisitor.SOAP_EXTENSION_ACTION, "someaction");
+        Operation operationMock = mock(Operation.class);
+        when(operationMock.getExtensions()).thenReturn(extensions);
+        Optional<Policy> policy = visitor.visit(mock(OpenAPI.class), operationMock);
+        assertFalse(policy.isPresent());
+    }
+
+    @Test
+    public void operationWithoutSoapAction() throws Exception {
+        Map<String, Object> extensions = new HashMap<>();
+        extensions.put(RestToSoapOAIOperationVisitor.SOAP_EXTENSION_ENVELOPE, "<soap:envelope></soap:envelope>");
+        Operation operationMock = mock(Operation.class);
+        when(operationMock.getExtensions()).thenReturn(extensions);
+        Optional<Policy> policy = visitor.visit(mock(OpenAPI.class), operationMock);
+        assertTrue(policy.isPresent());
+        String configuration = policy.get().getConfiguration();
+        assertNotNull(configuration);
+        HashMap readConfig = new ObjectMapper().readValue(configuration, HashMap.class);
+        assertEquals(extensions.get(RestToSoapOAIOperationVisitor.SOAP_EXTENSION_ENVELOPE), readConfig.get("envelope"));
+        assertNull(extensions.get(RestToSoapOAIOperationVisitor.SOAP_EXTENSION_ACTION));
+    }
+
+    @Test
+    public void operationWithSoapData() throws Exception {
+        Map<String, Object> extensions = new HashMap<>();
+        extensions.put(RestToSoapOAIOperationVisitor.SOAP_EXTENSION_ENVELOPE, "<soap:envelope></soap:envelope>");
+        extensions.put(RestToSoapOAIOperationVisitor.SOAP_EXTENSION_ACTION, "someaction");
+        Operation operationMock = mock(Operation.class);
+        when(operationMock.getExtensions()).thenReturn(extensions);
+        Optional<Policy> policy = visitor.visit(mock(OpenAPI.class), operationMock);
+        assertTrue(policy.isPresent());
+        String configuration = policy.get().getConfiguration();
+        assertNotNull(configuration);
+        HashMap readConfig = new ObjectMapper().readValue(configuration, HashMap.class);
+        assertEquals(extensions.get(RestToSoapOAIOperationVisitor.SOAP_EXTENSION_ENVELOPE), readConfig.get("envelope"));
+        assertEquals(extensions.get(RestToSoapOAIOperationVisitor.SOAP_EXTENSION_ACTION), readConfig.get("soapAction"));
+    }
+}


### PR DESCRIPTION
Addition of an OperationVisitor to generate rest-to-soap policy
based on the OpenAPI operation description

Addition of options into the Policy configuration bean

fix gravitee-io/issues#322