### PR TITLE
fix: rest-to-soap do not override request path info

### DIFF
--- a/src/main/java/io/gravitee/policy/rest2soap/configuration/SoapTransformerPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/rest2soap/configuration/SoapTransformerPolicyConfiguration.java
@@ -31,6 +31,8 @@ public class SoapTransformerPolicyConfiguration implements PolicyConfiguration {
 
     private boolean preserveQueryParams = false;
 
+    private boolean stripPath = false;
+
     public String getEnvelope() {
         return envelope;
     }
@@ -61,5 +63,14 @@ public class SoapTransformerPolicyConfiguration implements PolicyConfiguration {
 
     public void setPreserveQueryParams(boolean preserveQueryParams) {
         this.preserveQueryParams = preserveQueryParams;
+    }
+
+
+    public boolean isStripPath() {
+        return stripPath;
+    }
+
+    public void setStripPath(boolean stripPath) {
+        this.stripPath = stripPath;
     }
 }

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -33,6 +33,12 @@
       "title": "Preserve Query Parameters",
       "description": "Define if the query parameters are propagated to the backend SOAP service",
       "type": "boolean"
+    },
+    "stripPath": {
+      "title": "Strip path",
+      "description": "Strip the path before propagating it to the backend SOAP service",
+      "type": "boolean",
+      "default": false
     }
   },
   "required": [


### PR DESCRIPTION
Fixes https://github.com/gravitee-io/issues/issues/4860

Here I used a "/" for `ATTR_REQUEST_ENDPOINT`, it has the effect to append a slash to the endpoint.

An other solution is to set  `ATTR_REQUEST_ENDPOINT` to an empty string.

But it implies to modify https://github.com/gravitee-io/gravitee-gateway/blob/713baf2a50d38303eea81bbfb9c67c3283ccfd47/gravitee-gateway-core/src/main/java/io/gravitee/gateway/core/endpoint/resolver/impl/TargetEndpointResolver.java#L105

```
else if (target.startsWith(URI_PATH_SEPARATOR) || target == "") {
            // Get the first group
            LoadBalancedEndpointGroup group = groupManager.getDefault();

            // Resolve to the next endpoint from group LB
            Endpoint endpoint = group.next();
            if (endpoint == null) {
                return createEndpoint(endpoint, null);
            }
```

wdyt @brasseld ?