### PR TITLE
Apim 2140 rest2soap

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,8 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@2.0
+    gravitee: gravitee-io/gravitee@4.1.0
+
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)
@@ -22,7 +23,7 @@ workflows:
     setup_release:
         when:
             matches:
-                pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+                pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
                 value: << pipeline.git.tag >>
         jobs:
             - gravitee/setup_plugin-release-config:
@@ -32,4 +33,4 @@ workflows:
                               - /.*/
                       tags:
                           only:
-                              - /^[0-9]+\.[0-9]+\.[0-9]+$/
+                              - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,14 +1,22 @@
 {
   "extends": [
-    "config:base",
-    "schedule:earlyMondays"
+    "config:base"
   ],
-  "prConcurrentLimit": 3,
   "rebaseWhen": "conflicted",
   "packageRules": [
     {
       "matchDatasources": ["orb"],
-      "rangeStrategy": "replace"
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true,
+      "automergeType": "branch",
+      "semanticCommitType": "ci"
+    },
+    {
+      "matchDepTypes": ["provided", "test", "build", "import", "parent"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true,
+      "automergeType": "branch",
+      "semanticCommitType": "chore"
     }
   ]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -30,11 +30,11 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <!-- <version>19</version> for version 19 java source is in verison 8, and [19.2.1] parent upgrade is fit, not [19.2] -->
-        <version>19.2.1</version>
+        <version>21.0.1</version>
     </parent>
 
     <properties>
+        <gravitee-bom.version>5.0.0</gravitee-bom.version>
         <gravitee-gateway-api.version>1.31.0</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.10.0</gravitee-policy-api.version>
         <gravitee-common.version>1.25.0</gravitee-common.version>
@@ -48,6 +48,19 @@
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Import bom to properly inherit all dependencies -->
+            <dependency>
+                <groupId>io.gravitee</groupId>
+                <artifactId>gravitee-bom</artifactId>
+                <version>${gravitee-bom.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <!-- Provided scope -->
@@ -75,7 +88,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -109,27 +121,6 @@
             </resource>
         </resources>
         <plugins>
-            <!--
-            <plugin>
-                <groupId>io.gravitee.maven.plugins</groupId>
-                <artifactId>json-schema-generator-maven-plugin</artifactId>
-                <version>${json-schema-generator-maven-plugin.version}</version>
-                <executions>
-                    <execution>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>generate-json-schemas</goal>
-                        </goals>
-                        <configuration>
-                            <includes>
-                                <include>io/gravitee/policy/rest2soap/configuration/SoapTransformerPolicyConfiguration.class</include>
-                            </includes>
-                            <outputDirectory>${json-schema-generator-maven-plugin.outputDirectory}</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>properties-maven-plugin</artifactId>

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -6,3 +6,4 @@ class=io.gravitee.policy.rest2soap.RestToSoapTransformerPolicy
 type=policy
 category=transformation
 icon=rest-to-soap.svg
+proxy=REQUEST

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,15 +1,16 @@
 {
-  "type" : "object",
-  "id" : "urn:jsonschema:io:gravitee:policy:rest2soap:configuration:SoapTransformerPolicyConfiguration",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
   "properties" : {
     "envelope" : {
       "title": "SOAP Envelope",
-      "description": "SOAP envelope used to invoke WS (support EL)",
+      "description": "SOAP envelope used to invoke WS. (support EL)",
       "type" : "string",
       "x-schema-form": {
         "type": "codemirror",
         "codemirrorOptions": {
-          "placeholder": "Place your SOAP envelope here",
+          "placeholder": "Place your SOAP envelope here.",
           "lineWrapping": true,
           "lineNumbers": true,
           "allowDropFileTypes": true,
@@ -17,26 +18,32 @@
           "mode": "xml"
         },
         "expression-language": true
+      },
+      "format": "gio-code-editor",
+      "gioConfig": {
+        "monacoEditorConfig": {
+          "language": "xml"
+        }
       }
     },
     "soapAction": {
       "title": "SOAP Action",
-      "description": "'SOAPAction' HTTP header send when invoking WS",
+      "description": "'SOAPAction' HTTP header send when invoking WS.",
       "type": "string"
     },
     "charset": {
       "title": "Charset",
-      "description": "This charset will be appended to the Content-Type header value",
+      "description": "This charset will be appended to the Content-Type header value.",
       "type": "string"
     },
     "preserveQueryParams": {
       "title": "Preserve Query Parameters",
-      "description": "Define if the query parameters are propagated to the backend SOAP service",
+      "description": "Define if the query parameters are propagated to the backend SOAP service.",
       "type": "boolean"
     },
     "stripPath": {
       "title": "Strip path",
-      "description": "Strip the path before propagating it to the backend SOAP service",
+      "description": "Strip the path before propagating it to the backend SOAP service.",
       "type": "boolean",
       "default": false
     }


### PR DESCRIPTION
**Issue**

APIM-2140

**Description**

- update renovate
- update cci & gravitee-parent
- update schema form & add exec phase
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.14.0-apim-2140-rest2soap-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-rest-to-soap/1.14.0-apim-2140-rest2soap-SNAPSHOT/gravitee-policy-rest-to-soap-1.14.0-apim-2140-rest2soap-SNAPSHOT.zip)
  <!-- Version placeholder end -->
